### PR TITLE
Fix incorrect handling of negative window size

### DIFF
--- a/lib/Protocol/HTTP2/Connection.pm
+++ b/lib/Protocol/HTTP2/Connection.pm
@@ -393,7 +393,7 @@ sub send_data {
         }
 
         # Flow control
-        if ( $l != 0 && $size == 0 ) {
+        if ( $l != 0 && $size <= 0 ) {
             $self->stream_blocked_data( $stream_id, $data );
             last;
         }

--- a/lib/Protocol/HTTP2/Stream.pm
+++ b/lib/Protocol/HTTP2/Stream.pm
@@ -362,7 +362,7 @@ sub stream_send_blocked {
     my $s = $self->{streams}->{$stream_id} or return undef;
 
     if ( length( $s->{blocked_data} )
-        && $self->stream_fcw_send($stream_id) != 0 )
+        && $self->stream_fcw_send($stream_id) > 0 )
     {
         $self->send_data($stream_id);
     }


### PR DESCRIPTION
Stream window size may become negative if endpoint sends some data
before peer advertise SETTINGS_INITIAL_WINDOW_SIZE, which is smaller
than default one [1].

Previously library didn't handle this case correctly and tried to send
negative amount of data resulting in fcw_send becoming 0, instead of
staying negative. As result on next stream window update from the peer,
window size was becoming bigger than real stream window size.

[1] https://tools.ietf.org/html/rfc7540#section-6.9.2
