### PR TITLE
fix spelling mistakes

### DIFF
--- a/lib/Protocol/HTTP2/Client.pm
+++ b/lib/Protocol/HTTP2/Client.pm
@@ -109,7 +109,7 @@ Initialize new client object
 
     my $client = Procotol::HTTP2::Client->new( %options );
 
-Availiable options:
+Available options:
 
 =over
 
@@ -456,7 +456,7 @@ sub shutdown {
 
 =head3 close
 
-Explicitly close connection (send GOAWAY frame). This is requred if client
+Explicitly close connection (send GOAWAY frame). This is required if client
 has keepalive option enabled.
 
 =cut

--- a/lib/Protocol/HTTP2/Server.pm
+++ b/lib/Protocol/HTTP2/Server.pm
@@ -110,7 +110,7 @@ Initialize new server object
 
     my $server = Procotol::HTTP2::Client->new( %options );
 
-Availiable options:
+Available options:
 
 =over
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Protocol-HTTP2.
We thought you might be interested in it too.

    Description: fix spelling mistakes
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2017-02-06
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libprotocol-http2-perl.git/plain/debian/patches/spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
