### PR TITLE
Prevent uninitialized warning

### DIFF
--- a/lib/Protocol/HTTP2/Frame/Data.pm
+++ b/lib/Protocol/HTTP2/Frame/Data.pm
@@ -54,7 +54,7 @@ sub decode {
     # Check length of data matched content-length in header
     if ( $frame_ref->{flags} & END_STREAM ) {
         my $slen = $con->stream_length( $frame_ref->{stream} );
-        if ( defined $slen
+        if ( defined $slen && defined $con->stream_data( $frame_ref->{stream} )
             && $slen != length $con->stream_data( $frame_ref->{stream} ) )
         {
             tracer->warning(


### PR DESCRIPTION
This is to prevent warning message as follows:

Use of uninitialized value in numeric ne (!=) at /usr/local/share/perl/5.24.1/Protocol/HTTP2/Frame/Data.pm line 57.