### PR TITLE
Adapt tests for OpenSSL 3.1

### DIFF
--- a/t/lib/PH2ClientServerTest.pm
+++ b/t/lib/PH2ClientServerTest.pm
@@ -43,7 +43,7 @@ sub server {
         if ( !$h{upgrade} && ( $h{npn} || $h{alpn} ) ) {
             eval {
                 $tls = AnyEvent::TLS->new(
-                    method    => 'tlsv1',
+                    method    => 'tlsv1_2',
                     cert_file => $tls_crt,
                     key_file  => $tls_key,
                 );
@@ -122,7 +122,7 @@ sub client {
     }
     elsif ( $h{npn} || $h{alpn} ) {
         eval {
-            $tls = AnyEvent::TLS->new( method => 'tlsv1', );
+            $tls = AnyEvent::TLS->new( method => 'tlsv1_2', );
 
             if ( delete $h{npn} ) {
 


### PR DESCRIPTION
From OpenSSL 3.1.0 protocols  SSL 3, TLS 1.0, TLS 1.1, and DTLS 1.0 only work at security level 0.
https://www.openssl.org/news/openssl-3.1-notes.html

Therefore, change protocol used in tests from TLSv1 to TLSv1.2.