### PR TITLE
Do not hardcode tlsv1 which is deprecated and disabled in some systems

### DIFF
--- a/t/lib/PH2ClientServerTest.pm
+++ b/t/lib/PH2ClientServerTest.pm
@@ -77,7 +77,7 @@ sub server {
             : (),
             on_error => sub {
                 $_[0]->destroy;
-                print "connection error\n";
+                print STDERR "connection error: $_[2]: $!\n";
             },
             on_eof => sub {
                 $handle->destroy;
@@ -168,7 +168,7 @@ sub client {
             autocork => 1,
             on_error => sub {
                 $_[0]->destroy;
-                print "connection error\n";
+                print STDERR "connection error: $_[2]: $!\n";
                 $w->send(0);
             },
             on_eof => sub {

--- a/t/lib/PH2ClientServerTest.pm
+++ b/t/lib/PH2ClientServerTest.pm
@@ -43,7 +43,6 @@ sub server {
         if ( !$h{upgrade} && ( $h{npn} || $h{alpn} ) ) {
             eval {
                 $tls = AnyEvent::TLS->new(
-                    method    => 'tlsv1',
                     cert_file => $tls_crt,
                     key_file  => $tls_key,
                 );
@@ -122,7 +121,7 @@ sub client {
     }
     elsif ( $h{npn} || $h{alpn} ) {
         eval {
-            $tls = AnyEvent::TLS->new( method => 'tlsv1', );
+            $tls = AnyEvent::TLS->new();
 
             if ( delete $h{npn} ) {
 


### PR DESCRIPTION
The PH2 test-suite hardcodes the use of tlsv1 (i.e., TLSv1.0) which has been deprecated (alongside TLSv1.1 since 2021 - see RFC 8996).

Using the value tlsv1_2 would be fine (tlsv1_3 is not a supported value yet) but leaving it up to the system to decide seems simpler to maintain.

This fixes https://github.com/vlet/p5-Protocol-HTTP2/issues/15

The first patch makes it easier to see what the error actually is - if a disabled TLS version is being used:


```diff
-t/09_client_server_tcp.t .. 
+t/09_client_server_tcp.t .. connection error: error:0A0C0103:SSL routines::internal error: Protocol error
```
