### PR TITLE
fix: incorrect END_HEADERS flag on CONTINUATION frames

### DIFF
--- a/lib/Protocol/HTTP2/Connection.pm
+++ b/lib/Protocol/HTTP2/Connection.pm
@@ -354,7 +354,7 @@ sub send_headers {
     $self->enqueue( HEADERS, $flags, $stream_id,
         { hblock => \substr( $header_block, 0, $max_size, '' ) } );
     while ( length($header_block) > 0 ) {
-        my $flags = length($header_block) <= $max_size ? 0 : END_HEADERS;
+        my $flags = length($header_block) <= $max_size ? END_HEADERS : 0;
         $self->enqueue( CONTINUATION, $flags,
             $stream_id, \substr( $header_block, 0, $max_size, '' ) );
     }
@@ -372,7 +372,7 @@ sub send_pp_headers {
         [ $promised_id, \substr( $header_block, 0, $max_size - 4, '' ) ] );
 
     while ( length($header_block) > 0 ) {
-        my $flags = length($header_block) <= $max_size ? 0 : END_HEADERS;
+        my $flags = length($header_block) <= $max_size ? END_HEADERS : 0;
         $self->enqueue( CONTINUATION, $flags,
             $stream_id, \substr( $header_block, 0, $max_size, '' ) );
     }


### PR DESCRIPTION
The statement is inverted. It supposed to be setting END_HEADER flag if header block is less than max size of the frame, as it will be the last CONTINUATION header frame to send.